### PR TITLE
arnested/go-version-action doesn't need GITHUB_TOKEN anymore

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: arnested/go-version-action@v1
         id: go-version
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Install Go ${{ steps.go-version.outputs.minimal }}
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Hi,

I'm the author of [arnested/go-version-action](https://github.com/marketplace/actions/go-version-action).

The action doesn't need a GITHUB_TOKEN anymore.

Instead of getting the Go releases from git tags using GitHub's API (and thus needing the token to avoid being rate limited) it pulls the versions from https://go.dev/dl/?mode=json&include=all.
